### PR TITLE
Some small changes to make the code a bit rustier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A todo list tracker written in rust with support for multiple lists
 
 # Usage
-```bash
+```
 $ todo
 todo 0.1.0
 simple command-line todo list

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,16 @@
 #[macro_use]
 extern crate rusqlite;
-use std::cmp::Ord;
+
 use structopt::StructOpt;
+
 mod database;
-use database::*;
 mod opt;
-use opt::Opt;
 mod task;
+
+use database::*;
+use opt::Opt;
+use std::cmp::Ord;
+
 fn main() {
     let opt = Opt::from_args();
     match opt {
@@ -15,7 +19,7 @@ fn main() {
             list,
             data,
         } => {
-            let task = string_from_vec(data);
+            let task = data.join(" ");
             match list {
                 Some(list) => new_task(task, priority.unwrap_or(0), list),
                 None => new_task_current(task, priority.unwrap_or(0)),
@@ -38,9 +42,8 @@ fn main() {
                 Some(list) => get_tasks(list),
                 None => get_current_tasks(),
             };
-            let order = order.unwrap_or("priority".to_string());
-            match &order[..] {
-                "num" => tasks.sort_by(|task, other| task.num.cmp(&other.num)),
+            match order.as_deref() {
+                Some("num") => tasks.sort_by(|task, other| task.num.cmp(&other.num)),
                 _ => tasks.sort_by(|task, other| {
                     other
                         .priority
@@ -53,7 +56,7 @@ fn main() {
             }
         }
         Opt::Edit { list, num, data } => {
-            let string = string_from_vec(data);
+            let string = data.join(" ");
             match list {
                 Some(list) => update_desc_list(num, string, list),
                 None => update_desc(num, string),
@@ -63,7 +66,7 @@ fn main() {
             if list_mode {
                 remove_list(value);
             } else {
-                match value.parse::<i32>() {
+                match value.parse() {
                     Ok(num) => remove_task(num),
                     Err(_) => panic!("Could not parse num"),
                 }
@@ -85,12 +88,4 @@ fn main() {
             };
         }
     }
-}
-
-fn string_from_vec(vec: Vec<String>) -> String {
-    let mut string = String::new();
-    for word in vec {
-        string.push_str(&format!("{} ", word)[..]);
-    }
-    string
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -34,12 +34,11 @@ pub struct Task {
 
 impl fmt::Display for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let out: String;
-        if self.complete {
-            out = format!("{} {:03}: {}", BOX_CHECKED, self.num, self.data);
+        let out = if self.complete {
+            format!("{} {:03}: {}", BOX_CHECKED, self.num, self.data)
         } else {
-            out = format!("{} {:03}: {}", BOX_UNCHECKED, self.num, self.data);
-        }
+            format!("{} {:03}: {}", BOX_UNCHECKED, self.num, self.data)
+        };
         match self.priority {
             Priority::LOW => write!(f, "{}", out.cyan()),
             Priority::MED => write!(f, "{}", out.yellow()),


### PR DESCRIPTION
I've made a few changes: 

- Removed function `string_from_vec()`, the builtin `Vec<String>::join(sep)` achieves the same.
- Removed an unnecessary allocation when choosing the order to list tasks.
- Leaned on type inference a bit harder.
- Used an if expression instead of using an uninitialized variable (in the impl of `Display` for `Task`).
- Separated `use` and `mod` statements (this one is personal preference but I think it reads more cleanly).

I also removed the strange syntax highlighting for the help message in `README.md`